### PR TITLE
Fix for bug when deleting redis from UI

### DIFF
--- a/src/_providers.tf
+++ b/src/_providers.tf
@@ -13,7 +13,11 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 
   client_id       = var.azure_service_principal.data.client_id
   tenant_id       = var.azure_service_principal.data.tenant_id

--- a/src/validations.json
+++ b/src/validations.json
@@ -1,0 +1,5 @@
+{
+  "do_not_delete": [
+    "azurerm_redis_cache.main"
+  ]
+}


### PR DESCRIPTION
Fixing this error when trying to decommission the Redis bundle from the UI:

> This feature is intended to avoid the unintentional destruction of nested Resources provisioned through some other means (for example, an ARM Template Deployment) - as such you must either remove these Resources, or disable this behaviour using the feature flag `prevent_deletion_if_contains_resources` within the `features` block when configuring the Provider, for example: `azurerm" { features { resource_group { prevent_deletion_if_contains_resources = false } } }` When that feature flag is set, Terraform will skip checking for any Resources within the Resource Group and delete this using the Azure API directly (which will clear up any nested resources).

The fix will force the deletion of the resource group, which will delete all the resources inside the resource group. Which is perfectly acceptable when trying to decommission a bundle.
