### PR TITLE
Requiring shard_count and adding systemassigned identity

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -72,27 +72,33 @@ params:
           default: false
       dependencies:
         enable_cluster:
-          required:
-            - shard_count
-          properties:
-            enable_cluster:
-              enum:
-                - true
-            shard_count:
-              type: integer
-              title: Redis cluster shard count
-              description: Set the number of shards in the Redis cluster.
-              enum:
-                - 1
-                - 2
-                - 3
-                - 4
-                - 5
-                - 6
-                - 7
-                - 8
-                - 9
-                - 10
+          oneOf:
+            - properties:
+                enable_cluster:
+                  enum:
+                    - true
+                shard_count:
+                  type: integer
+                  title: Redis cluster shard count
+                  description: Set the number of shards in the Redis cluster. You must enable Redis clustering and deploy that change before you can use this feature.
+                  enum:
+                    - 1
+                    - 2
+                    - 3
+                    - 4
+                    - 5
+                    - 6
+                    - 7
+                    - 8
+                    - 9
+                    - 10
+              required:
+                - shard_count
+            - properties:
+                enable_cluster:
+                  enum:
+                    - false
+
 
 connections:
   required:

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -72,30 +72,27 @@ params:
           default: false
       dependencies:
         enable_cluster:
-          oneOf:
-            - properties:
-                enable_cluster:
-                  enum:
-                    - true
-                shard_count:
-                  type: integer
-                  title: Redis cluster shard count
-                  description: Set the number of shards in the Redis cluster. You must enable Redis clustering and deploy that change before you can use this feature.
-                  enum:
-                    - 1
-                    - 2
-                    - 3
-                    - 4
-                    - 5
-                    - 6
-                    - 7
-                    - 8
-                    - 9
-                    - 10
-            - properties:
-                enable_cluster:
-                  enum:
-                    - false
+          required:
+            - shard_count
+          properties:
+            enable_cluster:
+              enum:
+                - true
+            shard_count:
+              type: integer
+              title: Redis cluster shard count
+              description: Set the number of shards in the Redis cluster.
+              enum:
+                - 1
+                - 2
+                - 3
+                - 4
+                - 5
+                - 6
+                - 7
+                - 8
+                - 9
+                - 10
 
 connections:
   required:

--- a/src/main.tf
+++ b/src/main.tf
@@ -17,6 +17,10 @@ resource "azurerm_redis_cache" "main" {
   sku_name             = "Premium"
   subnet_id            = var.vnet.data.infrastructure.default_subnet_id
 
+  identity {
+    type = "SystemAssigned"
+  }
+
   public_network_access_enabled = false
 
   shard_count = var.cluster.enable_cluster ? var.cluster.shard_count : 0


### PR DESCRIPTION
Per Dave's suggestion, removing `oneOf` schema dependency and using a single dependency format. Also added SystemAssigned identity for futureproofing.